### PR TITLE
[FORENG-4387] constrain Cython version to exclude known-buggy version 3.0.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "wheel", "numpy", "scipy", "Cython"]
+requires = ["setuptools", "wheel", "numpy", "scipy", "Cython<=3.0.3"]
 build-backend = "setuptools.build_meta"


### PR DESCRIPTION
Addresses https://github.com/ihmeuw-msca/spmat/issues/15